### PR TITLE
feat: ✨ prettier plugin tailwind css 적용

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,8 @@
   "tabWidth": 2,
   "semi": false,
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "pluginSearchDirs": false
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "commitizen": "^4.3.0",
     "cz-customizable": "^7.0.0",
     "cz-git": "^1.6.1",
-    "msw": "^1.2.1"
+    "msw": "^1.2.1",
+    "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.3.0"
   },
   "msw": {
     "workerDirectory": "public"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+// prettier.config.js
+module.exports = {
+  plugins: [require('prettier-plugin-tailwindcss')],
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 module.exports = {
+  tailwindConfig: './styles/tailwind.config.js',
+
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,16 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-plugin-tailwindcss@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.3.0.tgz#8299b307c7f6467f52732265579ed9375be6c818"
+  integrity sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==
+
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"


### PR DESCRIPTION
## 작업분류
- [ ] 버그수정
- [x] 신규 기능
- [x] 리팩토링
- [x] 기타

## 작업내용
[feat: ✨ prettier plugin tailwind css 적용](https://github.com/3DAsset-eCommerce/3D-FE/commit/16594ab3ffb584619509775ff8e247bdb78cf4fb)


## 변경 사항
- 스타일 적용 시 통일성을 위해 tailwind용 prettier를 적용했습니다.
- 띄어쓰기 같은 경우는 tailwind prettier가 아닌 prettier에 따로 적용을 해야만해서, 다른코드에 영향을 줄 것같아 prettier의 useTabs설정은 하지 않았습니다.
