### PR TITLE
feat: :sparkles: 마이에셋-주문내역 조회용 캘린더 ui 퍼블리싱

### DIFF
--- a/src/components/myPage/orderHistory/calendar/MyOrderCalendar.module.css
+++ b/src/components/myPage/orderHistory/calendar/MyOrderCalendar.module.css
@@ -1,0 +1,46 @@
+.calendar {
+  border: none;
+  background-color: #171a1d;
+  color: #737c85;
+}
+
+.customHeaderContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+  padding: 0 12px 0 24px;
+  background-color: #171a1d;
+  border: none;
+  color: #737c85;
+  margin-bottom: 8px;
+
+  .monthButton {
+    color: #737c85;
+    font-weight: 600;
+  }
+  .title {
+    .year {
+      background-color: #171a1d;
+      margin-right: 12px;
+      border: none;
+    }
+    .month {
+      margin-right: 12px;
+    }
+  }
+}
+
+.selectedDay,
+.unselectedDay {
+  color: #737c85;
+  padding: 5px 1px 0 0;
+  width: 32px;
+  height: 32px;
+}
+
+.selectedDay {
+  background-color: #3399ff;
+  border-radius: 50%;
+  color: #fcfcfc;
+}

--- a/src/components/myPage/orderHistory/calendar/MyOrderCalendar.tsx
+++ b/src/components/myPage/orderHistory/calendar/MyOrderCalendar.tsx
@@ -3,11 +3,86 @@ import { useState } from 'react'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import { ko } from 'date-fns/esm/locale' //한국어 설정
+import s from './MyOrderCalendar.module.css'
 import Image from 'next/image'
+import { getMonth, getYear } from 'date-fns'
+
+type CustomHeaderProps = {
+  date: Date
+  changeYear: (year: number) => void
+  decreaseMonth: () => void
+  increaseMonth: () => void
+  prevMonthButtonDisabled: boolean
+  nextMonthButtonDisabled: boolean
+}
 
 export default function MyOrderCalendar() {
   const [startDate, setStartDate] = useState<Date | null>(new Date())
   const [endDate, setEndDate] = useState<Date | null>(new Date())
+
+  const YEARS = Array.from(
+    { length: getYear(new Date()) + 1 - 2000 },
+    (_, i) => getYear(new Date()) - i,
+  )
+  const MONTHS = [
+    '1월',
+    '2월',
+    '3월',
+    '4월',
+    '5월',
+    '6월',
+    '7월',
+    '8월',
+    '9월',
+    '10월',
+    '11월',
+    '12월',
+  ]
+
+  // react-datePicker Header부분 커스텀 함수
+  const customRenderHeader: React.FC<CustomHeaderProps> = ({
+    date,
+    changeYear,
+    decreaseMonth,
+    increaseMonth,
+    prevMonthButtonDisabled,
+    nextMonthButtonDisabled,
+  }) => {
+    return (
+      <div className={s.customHeaderContainer}>
+        <button
+          type="button"
+          onClick={decreaseMonth}
+          className={s.monthButton}
+          disabled={prevMonthButtonDisabled}
+        >
+          ⟨
+        </button>
+        <div className={s.title}>
+          <select
+            value={getYear(date)}
+            className={s.year}
+            onChange={({ target: { value } }) => changeYear(+value)}
+          >
+            {YEARS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <span className={s.month}>{MONTHS[getMonth(date)]}</span>
+        </div>
+        <button
+          type="button"
+          onClick={increaseMonth}
+          className={s.monthButton}
+          disabled={nextMonthButtonDisabled}
+        >
+          ⟩{' '}
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="mb-8 mt-6 flex w-[65%] text-neutral-navy-200">
@@ -24,6 +99,11 @@ export default function MyOrderCalendar() {
           startDate={startDate}
           endDate={endDate}
           onChange={(date) => setStartDate(date)}
+          calendarClassName={s.calendar} // 달력 팝업 스타일링
+          renderCustomHeader={customRenderHeader}
+          dayClassName={(d) =>
+            d.getDate() === startDate!.getDate() ? s.selectedDay : s.unselectedDay
+          }
           className="border-non h-[2.3rem] bg-neutral-navy-950 pl-2.5 text-[1.6rem] text-neutral-navy-200"
         />
         <Image src="/icons/calendar.svg" alt="calendar icon" width={20} height={20} />
@@ -44,6 +124,11 @@ export default function MyOrderCalendar() {
           startDate={startDate}
           endDate={endDate}
           onChange={(date) => setEndDate(date)}
+          calendarClassName={s.calendar} // 달력 팝업 스타일링
+          renderCustomHeader={customRenderHeader}
+          dayClassName={(d) =>
+            d.getDate() === startDate!.getDate() ? s.selectedDay : s.unselectedDay
+          }
           className="border-non h-[2.3rem] bg-neutral-navy-950 pl-2.5 text-[1.6rem] text-neutral-navy-200"
         />
         <Image src="/icons/calendar.svg" alt="calendar icon" width={20} height={20} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,6 +26,32 @@ body {
   min-height: 100vh;
   overflow-y: auto;
   font-size: 1.6rem;
+
+  .react-datepicker-popper {
+    font-size: medium;
+    min-width: 17%;
+    color: #5b5b5b;
+    .react-datepicker__header {
+      min-width: 17%;
+      margin-top: 8px;
+      background-color: #171a1d;
+      color: #737c85;
+      border-bottom: none;
+      .react-datepicker__day-names {
+        .react-datepicker__day-name {
+          color: #737c85;
+          width: 32px;
+        }
+      }
+    }
+    .react-datepicker__triangle {
+      display: none;
+    }
+    .react-datepicker__day--outside-month {
+      cursor: default;
+      visibility: hidden;
+    }
+  }
 }
 
 * {


### PR DESCRIPTION
## 작업분류
- [ ] 버그수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

## 작업내용
- react-datePicker 커스텀 완료
- 내역조회 시작일과 종료일 로직 진행 중

## 리뷰 요구사항
- 라이브러리 적용 후 UI를 디자인에 맞게 커스텀 했습니다.
- tailwind로 적용되지 않는 부분이 있어 global.css와 .module.css에 스타일속성들을 추가 및 사용했습니다.
- 내역조회 시작일과 종료일 선택 후 조회버튼을 누르면 주문내역이 필터링 되는 로직을 진행 중에 있습니다.

## 변경 사항
In Progress #36 